### PR TITLE
Rename close to resolve

### DIFF
--- a/slack/models/headline_post.py
+++ b/slack/models/headline_post.py
@@ -67,7 +67,7 @@ class HeadlinePost(models.Model):
 
             actions.add_element(Button(":pencil2: Edit", self.EDIT_INCIDENT_BUTTON, value=self.incident.pk))
 
-            actions.add_element(Button(":white_check_mark: Close", self.CLOSE_INCIDENT_BUTTON, value=self.incident.pk))
+            actions.add_element(Button(":white_check_mark: Resolve", self.CLOSE_INCIDENT_BUTTON, value=self.incident.pk))
 
             msg.add_block(actions)
 


### PR DESCRIPTION
Renamed `close` to `resolve` in the headline post.

Behind the scenes, this will still be called closed, this is a just a visual change.